### PR TITLE
Fix/undefined post variable

### DIFF
--- a/post-finder.php
+++ b/post-finder.php
@@ -294,9 +294,11 @@ class NS_Post_Finder {
 				?>
 			</ul>
 
+			<?php if ( ! empty( $posts ) ) : ?>
 			<p class="counter">
 				<?php printf( __( '<span class="current-count">%d</span> of <span class="max-count">%d</span> maximum items', 'post_finder' ), intval( count( $posts ) ), intval( $options['limit'] ) ); ?> <span class="message">You'll need to remove an item from the list before you can add another.</span>
 			</p>
+			<?php endif; ?>
 
 				<div class="search-container">
 

--- a/post-finder.php
+++ b/post-finder.php
@@ -294,11 +294,9 @@ class NS_Post_Finder {
 				?>
 			</ul>
 
-			<?php if ( ! empty( $posts ) ) : ?>
 			<p class="counter">
-				<?php printf( __( '<span class="current-count">%d</span> of <span class="max-count">%d</span> maximum items', 'post_finder' ), intval( count( $posts ) ), intval( $options['limit'] ) ); ?> <span class="message">You'll need to remove an item from the list before you can add another.</span>
+				<?php printf( __( '<span class="current-count">%d</span> of <span class="max-count">%d</span> maximum items', 'post_finder' ), intval( empty( $posts ) ? 0 : count( $posts ) ), intval( $options['limit'] ) ); ?> <span class="message">You'll need to remove an item from the list before you can add another.</span>
 			</p>
-			<?php endif; ?>
 
 				<div class="search-container">
 


### PR DESCRIPTION
Fixes a PHP notice when adding a new post and there are no selected posts.

```Notice: Undefined variable: posts in /srv/www/wordpress-default/htdocs/wp-content/plugins/post-finder/post-finder.php on line 298```
